### PR TITLE
Port to v1 config format

### DIFF
--- a/squid-controller.json
+++ b/squid-controller.json
@@ -1,34 +1,34 @@
 {
-  "id":"squid",
   "kind":"ReplicationController",
-  "apiVersion":"v1beta1",
-  "desiredState":{
+  "apiVersion":"v1",
+  "metadata":{
+    "name":"squid"
+  },
+  "spec":{
     "replicas":1,
-    "replicaSelector":{
+    "selector":{
       "component":"squid"
-      },
-      "podTemplate":{
-        "desiredState":{
-          "manifest":{
-            "version":"v1beta1",
-            "id":"squid",
-            "containers":[
-            {
-              "name":"squid",
-              "image":"jpetazzo/squid-in-a-can",
-              "ports":[
-              {
-                "name":"squid",
-                "containerPort":3129
-              }
-              ]
-            }
-            ]
-          }
-          },
-          "labels":{
-            "component":"squid"
-          }
+    },
+    "template":{
+      "metadata":{
+        "labels":{
+          "component":"squid"
         }
+      },
+      "spec":{
+        "containers":[
+        {
+          "name":"squid",
+          "image":"jpetazzo/squid-in-a-can",
+          "ports":[
+          {
+            "name":"squid",
+            "containerPort":3129
+          }
+          ]
+        }
+        ]
       }
     }
+  }
+}

--- a/squid-service.json
+++ b/squid-service.json
@@ -1,10 +1,18 @@
 {
-  "id": "squid",
   "kind": "Service",
-  "apiVersion": "v1beta1",
-  "port": 3129,
-  "containerPort": 3129,
-  "selector": {
-    "component": "squid",
+  "apiVersion": "v1",
+  "metadata":{
+    "name":"squid"
+  },
+  "spec":{
+    "ports":[
+    {
+      "port": 3129,
+      "containerPort": 3129
+    }
+    ],
+    "selector": {
+      "component": "squid"
+    }
   }
 }


### PR DESCRIPTION
The config file format has changed, and the old "v1beta" format is not supported. This changes them to the new format. Tested on Google Container Engine on 2015/10/17.
